### PR TITLE
chore(ci): deployment config deprecation

### DIFF
--- a/.github/openshift/deploy.backend.yml
+++ b/.github/openshift/deploy.backend.yml
@@ -102,22 +102,6 @@ objects:
       idir-form-password: "${IDIR_FORM_PASSWORD}"
       bceid-form-password: "${BCEID_FORM_PASSWORD}"
   - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${IMAGE_TAG}
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
-  - apiVersion: v1
     kind: Deployment
     metadata:
       labels:

--- a/.github/openshift/deploy.backend.yml
+++ b/.github/openshift/deploy.backend.yml
@@ -105,7 +105,7 @@ objects:
       ches-client-secret: "${CHES_CLIENT_SECRET}"
       idir-form-password: "${IDIR_FORM_PASSWORD}"
       bceid-form-password: "${BCEID_FORM_PASSWORD}"
-  - apiVersion: v1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       labels:
@@ -255,7 +255,7 @@ objects:
                 initialDelaySeconds: 60
                 periodSeconds: 30
                 timeoutSeconds: 5
-  - apiVersion: apps/v1
+  - apiVersion: v1
     kind: Service
     metadata:
       labels:

--- a/.github/openshift/deploy.backend.yml
+++ b/.github/openshift/deploy.backend.yml
@@ -112,32 +112,23 @@ objects:
           referencePolicy:
             type: Local
   - apiVersion: v1
-    kind: DeploymentConfig
+    kind: Deployment
     metadata:
       labels:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           initContainers:
             - name: ${NAME}-init
@@ -281,7 +272,7 @@ objects:
           port: 80
           targetPort: 3000
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:

--- a/.github/openshift/deploy.backend.yml
+++ b/.github/openshift/deploy.backend.yml
@@ -68,6 +68,10 @@ parameters:
   - name: INIT_IMAGE
     description: Imaged used by the init process
     value: flyway/flyway
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - apiVersion: v1
     kind: ConfigMap
@@ -144,6 +148,8 @@ objects:
                       key: database-user
                 - name: FLYWAY_BASELINE_ON_MIGRATE
                   value: "true"
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               volumeMounts:
                 - mountPath: /flyway/sql
                   name: migration

--- a/.github/openshift/deploy.backend.yml
+++ b/.github/openshift/deploy.backend.yml
@@ -22,6 +22,12 @@ parameters:
   - name: IMAGE_TAG
     description: Image tag to use
     value: latest
+  - name: REGISTRY
+    description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
+    value: ghcr.io
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
   - name: CPU_LIMIT
@@ -162,7 +168,7 @@ objects:
               configMap:
                 name: postgres-configmap
           containers:
-            - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               imagePullPolicy: Always
               name: ${NAME}
               env:

--- a/.github/openshift/deploy.backend.yml
+++ b/.github/openshift/deploy.backend.yml
@@ -255,7 +255,7 @@ objects:
                 initialDelaySeconds: 60
                 periodSeconds: 30
                 timeoutSeconds: 5
-  - apiVersion: v1
+  - apiVersion: apps/v1
     kind: Service
     metadata:
       labels:

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -31,9 +31,6 @@ parameters:
     name: DB_PVC_SIZE
     required: true
     value: 1Gi
-  - name: REGISTRY
-    description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
-    value: ghcr.io
   - name: ORG
     description: Organization name
     value: bcgov

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -77,26 +77,17 @@ objects:
           name: ${REGISTRY}/${PROMOTE}
         referencePolicy:
           type: Local
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       name: ${NAME}-${ZONE}-${COMPONENT}
       labels:
         app: ${NAME}-${ZONE}
     spec:
       replicas: 1
-      triggers:
-      - type: ConfigChange
-      - type: ImageChange
-        imageChangeParams:
-          automatic: true
-          containerNames:
-          - ${NAME}
-          from:
-            kind: ImageStreamTag
-            name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: Recreate
         recreateParams:
@@ -107,7 +98,7 @@ objects:
           name: ${NAME}-${ZONE}-${COMPONENT}
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           volumes:
             - name: ${NAME}-${ZONE}-${COMPONENT}
@@ -198,6 +189,6 @@ objects:
           protocol: TCP
           targetPort: 5432
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
       sessionAffinity: None
       type: ClusterIP

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -32,6 +32,12 @@ parameters:
     required: true
     value: 1Gi
   - name: REGISTRY
+    description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
+    value: ghcr.io
+  - name: ORG
+    description: Organization name
+    value: bcgov
+  - name: REGISTRY
     value: image-registry.openshift-image-registry.svc:5000
   - name: PROMOTE
     description: Image (namespace/name:tag) to promote/import
@@ -106,7 +112,7 @@ objects:
                 claimName: ${NAME}-${ZONE}-${COMPONENT}
           containers:
             - name: ${NAME}
-              image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               ports:
                 - containerPort: 5432
                   protocol: TCP

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -42,6 +42,10 @@ parameters:
   - name: PROMOTE
     description: Image (namespace/name:tag) to promote/import
     value: openshift/postgresql:12
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - apiVersion: v1
     kind: Secret
@@ -142,6 +146,8 @@ objects:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: database-user
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               volumeMounts:
                 - name: ${NAME}-${ZONE}-${COMPONENT}
                   mountPath: "/var/lib/pgsql/data"

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -67,22 +67,6 @@ objects:
         requests:
           storage: "${DB_PVC_SIZE}"
       storageClassName: netapp-file-standard
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      name: ${NAME}-${ZONE}-${COMPONENT}
-      labels:
-        app: ${NAME}-${ZONE}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-      - name: ${IMAGE_TAG}
-        from:
-          kind: DockerImage
-          name: ${REGISTRY}/${PROMOTE}
-        referencePolicy:
-          type: Local
   - kind: Deployment
     apiVersion: apps/v1
     metadata:

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -96,7 +96,7 @@ objects:
                 claimName: ${NAME}-${ZONE}-${COMPONENT}
           containers:
             - name: ${NAME}
-              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
+              image: ${REGISTRY}/${PROMOTE}
               ports:
                 - containerPort: 5432
                   protocol: TCP

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,10 +1,8 @@
 {
   "name": "old-growth-backend",
-  "version": "0.0.1",
   "description": "Backend for old growth project",
   "private": true,
-  "license": "UNLICENSED",
-  "author": "Derek Roberts, Catherine Meng, Maria Martinez, Paulo Cruz",
+  "license": "Apache-2.0",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",


### PR DESCRIPTION
Replace deprecated Deployment Configs with Deployments. Closes https://github.com/bcgov/nr-old-growth/issues/277

Unfortunately there will be some downtime when this deploys.

Steps:
- Delete DeploymentConfigs for TEST database and backend
- Delete DeploymentConfigs for PROD database and backend
- Merge this PR
- Let deployments to TEST and PROD complete
- Delete previous DeploymentConfigs

Note: Scaling deployment configs should have worked, but they sometimes scaled back up regardless.  Deleting them is safer, especially for the database!