### PR TITLE
chore(ci): deploymentconfig deprecation

### DIFF
--- a/.github/openshift/deploy.backend.yml
+++ b/.github/openshift/deploy.backend.yml
@@ -53,6 +53,10 @@ parameters:
   - name: INIT_IMAGE
     description: Imaged used by the init process
     value: flyway/flyway
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - apiVersion: v1
     kind: ConfigMap
@@ -129,6 +133,8 @@ objects:
                       key: database-user
                 - name: FLYWAY_BASELINE_ON_MIGRATE
                   value: "true"
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               volumeMounts:
                 - mountPath: /flyway/sql
                   name: migration

--- a/.github/openshift/deploy.backend.yml
+++ b/.github/openshift/deploy.backend.yml
@@ -19,9 +19,6 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: IMAGE_TAG
-    description: Image tag to use
-    value: latest
   - name: DOMAIN
     value: apps.silver.devops.gov.bc.ca
   - name: CPU_LIMIT
@@ -35,6 +32,9 @@ parameters:
   - name: REGISTRY
     description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
     value: ghcr.io
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - name: PROMOTE
     description: Image (namespace/name:tag) to promote/import
     value: bcgov/nr-old-growth:prod-backend
@@ -95,49 +95,24 @@ objects:
       ches-client-secret: "${CHES_CLIENT_SECRET}"
       idir-form-password: "${IDIR_FORM_PASSWORD}"
       bceid-form-password: "${BCEID_FORM_PASSWORD}"
-  - apiVersion: v1
-    kind: ImageStream
-    metadata:
-      labels:
-        app: ${NAME}-${ZONE}
-      name: ${NAME}-${ZONE}-${COMPONENT}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-        - name: ${IMAGE_TAG}
-          from:
-            kind: DockerImage
-            name: ${REGISTRY}/${PROMOTE}
-          referencePolicy:
-            type: Local
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       labels:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-              - ${NAME}
-            from:
-              kind: ImageStreamTag
-              name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           initContainers:
             - name: ${NAME}-init
@@ -171,7 +146,7 @@ objects:
               configMap:
                 name: postgres-configmap
           containers:
-            - image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+            - image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               imagePullPolicy: Always
               name: ${NAME}
               env:
@@ -281,7 +256,7 @@ objects:
           port: 80
           targetPort: 3000
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:

--- a/.github/openshift/deploy.backend.yml
+++ b/.github/openshift/deploy.backend.yml
@@ -1,18 +1,9 @@
 apiVersion: template.openshift.io/v1
 kind: Template
-metadata:
-  name: ${NAME}
-  annotations:
-    description: "Nr-Old-Growth"
-    tags: "nrog"
-    iconClass: icon-js
-labels:
-  app: ${NAME}-${ZONE}
-  app.kubernetes.io/part-of: ${NAME}-${ZONE}
 parameters:
   - name: NAME
     description: Module name
-    value: nrog
+    value: nr-old-growth
   - name: COMPONENT
     description: Component name
     value: backend

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -25,6 +25,10 @@ parameters:
   - name: ORG
     description: Organization name
     value: bcgov
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - apiVersion: v1
     kind: Secret
@@ -125,6 +129,8 @@ objects:
                     secretKeyRef:
                       name: ${NAME}-${ZONE}-${COMPONENT}
                       key: database-user
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               volumeMounts:
                 - name: ${NAME}-${ZONE}-${COMPONENT}
                   mountPath: "/var/lib/pgsql/data"

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -1,18 +1,9 @@
 apiVersion: template.openshift.io/v1
 kind: Template
-metadata:
-  name: ${NAME}
-  annotations:
-    description: "Nr-Old-Growth"
-    tags: "nrog"
-    iconClass: icon-js
-labels:
-  app: ${NAME}-${ZONE}
-  app.kubernetes.io/part-of: ${NAME}-${ZONE}
 parameters:
   - name: NAME
     description: Product name
-    value: nrog
+    value: nr-old-growth
   - name: COMPONENT
     description: Component name
     value: database
@@ -88,7 +79,7 @@ objects:
                 claimName: ${NAME}-${ZONE}-${COMPONENT}
           containers:
             - name: ${NAME}
-              image: openshift/postgresql:12
+              image: image-registry.openshift-image-registry.svc:5000/openshift/postgresql:12
               ports:
                 - containerPort: 5432
                   protocol: TCP

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -19,9 +19,6 @@ parameters:
   - name: ZONE
     description: Deployment zone, e.g. pr-### or prod
     required: true
-  - name: IMAGE_TAG
-    description: Image tag to use
-    value: latest
   - description: Password for the PostgreSQL connection user.
     from: "[a-zA-Z0-9]{16}"
     generate: expression
@@ -32,7 +29,11 @@ parameters:
     required: true
     value: 1Gi
   - name: REGISTRY
-    value: image-registry.openshift-image-registry.svc:5000
+    description: Container registry to import from (internal is image-registry.openshift-image-registry.svc:5000)
+    value: ghcr.io
+  - name: ORG
+    description: Organization name
+    value: bcgov
   - name: PROMOTE
     description: Image (namespace/name:tag) to promote/import
     value: openshift/postgresql:12
@@ -61,42 +62,17 @@ objects:
         requests:
           storage: "${DB_PVC_SIZE}"
       storageClassName: netapp-file-standard
-  - kind: ImageStream
-    apiVersion: v1
-    metadata:
-      name: ${NAME}-${ZONE}-${COMPONENT}
-      labels:
-        app: ${NAME}-${ZONE}
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-      - name: ${IMAGE_TAG}
-        from:
-          kind: DockerImage
-          name: ${REGISTRY}/${PROMOTE}
-        referencePolicy:
-          type: Local
-  - kind: DeploymentConfig
-    apiVersion: v1
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       name: ${NAME}-${ZONE}-${COMPONENT}
       labels:
         app: ${NAME}-${ZONE}
     spec:
       replicas: 1
-      triggers:
-      - type: ConfigChange
-      - type: ImageChange
-        imageChangeParams:
-          automatic: true
-          containerNames:
-          - ${NAME}
-          from:
-            kind: ImageStreamTag
-            name: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: Recreate
         recreateParams:
@@ -107,7 +83,7 @@ objects:
           name: ${NAME}-${ZONE}-${COMPONENT}
           labels:
             app: ${NAME}-${ZONE}
-            deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+            deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
           volumes:
             - name: ${NAME}-${ZONE}-${COMPONENT}
@@ -115,7 +91,7 @@ objects:
                 claimName: ${NAME}-${ZONE}-${COMPONENT}
           containers:
             - name: ${NAME}
-              image: ${NAME}-${ZONE}-${COMPONENT}:${IMAGE_TAG}
+              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
               ports:
                 - containerPort: 5432
                   protocol: TCP
@@ -198,6 +174,6 @@ objects:
           protocol: TCP
           targetPort: 5432
       selector:
-        deploymentconfig: ${NAME}-${ZONE}-${COMPONENT}
+        deployment: ${NAME}-${ZONE}-${COMPONENT}
       sessionAffinity: None
       type: ClusterIP

--- a/.github/openshift/deploy.database.yml
+++ b/.github/openshift/deploy.database.yml
@@ -34,9 +34,6 @@ parameters:
   - name: ORG
     description: Organization name
     value: bcgov
-  - name: PROMOTE
-    description: Image (namespace/name:tag) to promote/import
-    value: openshift/postgresql:12
 objects:
   - apiVersion: v1
     kind: Secret
@@ -91,7 +88,7 @@ objects:
                 claimName: ${NAME}-${ZONE}-${COMPONENT}
           containers:
             - name: ${NAME}
-              image: ${REGISTRY}/${ORG}/${NAME}/${COMPONENT}:${ZONE}
+              image: openshift/postgresql:12
               ports:
                 - containerPort: 5432
                   protocol: TCP


### PR DESCRIPTION
Replaces deprecated Deployment Configs with Deployments. Also removes image streams.  Closes https://github.com/bcgov/nr-old-growth/issues/277.

Unfortunately there will be some downtime when this deploys.

Steps:
- Delete DeploymentConfigs for TEST database and backend
- Delete DeploymentConfigs for PROD database and backend
- Merge this PR
- Let deployments to TEST and PROD complete
- Delete previous DeploymentConfigs

Note: Scaling deployment configs should have worked, but they sometimes scaled back up regardless.  Deleting them is safer, especially for the database!

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-old-growth-291-backend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-old-growth/actions/workflows/merge-main.yml)