### PR TITLE
chore: Fixed GitHub Actions Workflow

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -64,8 +64,8 @@ jobs:
             # Current changelog
 
             ${{ steps.changelog.outputs.clean_changelog }}
-          comment_tag: "# Current changelog"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-tag: "# Current changelog"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   pr-greeting:
     name: PR Greeting


### PR DESCRIPTION
Fixed input parameters in GitHub Actions workflow:

1. Corrected comment_tag to comment-tag.
2. Replaced GITHUB_TOKEN with github-token for consistency with the action's expected inputs.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-old-growth-356-backend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-old-growth/actions/workflows/merge-main.yml)