### PR TITLE
chore: adjust node version for merge workflow tests

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -31,7 +31,7 @@ jobs:
             npm ci
             npm run test:cov
           dir: backend
-          node_version: 16
+          node_version: 20
           sonar_args: >
             -Dsonar.exclusions=**/coverage/**,**/examples/**,**/pages/**
             -Dsonar.organization=bcgov-sonarcloud


### PR DESCRIPTION
Node version was still 16 in merge-main.yml.  Changed to 20.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-old-growth-431-backend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-old-growth/actions/workflows/merge-main.yml)