### PR TITLE
chore(ci): shai hulud 2 patch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     entrypoint:
       - "sh"
       - "-c"
-      - "npm ci && npm run start"
+      - "npm ci --ignore-scripts && npm run start"
     environment:
       NODE_ENV: development
       POSTGRESQL_HOST: database


### PR DESCRIPTION
The `ci --ignore-scripts` flag prevents pre-loading of npm scripts, which is the primary way Shai Hulud spreads.  This should ideally be used everywhere, although there are exceptions.

Re: [Shai Hulud 2](https://www.sonatype.com/blog/the-second-coming-of-shai-hulud-attackers-innovating-on-npm)
Fix: via @basilv

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-old-growth-463-backend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-old-growth/actions/workflows/merge-main.yml)