### PR TITLE
chore(ci): migrate Trivy scanners flag to 'misconfig'

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,7 +57,7 @@ jobs:
           output: "trivy-results.sarif"
           ignore-unfixed: true
           scan-type: "fs"
-          scanners: "vuln,secret,config"
+          scanners: "vuln,secret,misconfig"
           severity: "CRITICAL,HIGH"
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Updates deprecated '--scanners config' to '--scanners misconfig' to align with updated standards.

---
Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://nr-old-growth-479-backend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/nr-old-growth/actions/workflows/merge-main.yml)